### PR TITLE
Added Options Method

### DIFF
--- a/R/ambiorix.R
+++ b/R/ambiorix.R
@@ -207,6 +207,30 @@ Ambiorix <- R6::R6Class(
 
       invisible(self)
     },
+#' @details OPTIONS Method
+#'
+#' Add routes to listen to.
+#'
+#' @param path Route to listen to.
+#' @param handler Function that accepts the request and returns an object
+#' describing an httpuv response, e.g.: [response()].
+#' @param error Handler function to run on error.
+    options = function(path, handler, error = NULL){
+      assert_that(valid_path(path))
+      assert_that(not_missing(handler))
+      assert_that(is_handler(handler))
+
+      private$.routes[[uuid()]] <- list(
+        route = Route$new(path),
+        path = path,
+        fun = handler,
+        method = "OPTIONS",
+        res = Response$new(),
+        error = error %error% self$error
+      )
+
+      invisible(self)
+    },
 #' @details All Methods
 #' 
 #' Add routes to listen to for all methods `GET`, `POST`, `PUT`, `DELETE`, and `PATCH`.


### PR DESCRIPTION
Because Ambiorix is unopinionated it should give users the ability to handle the OPTIONS http method. With this in place you can handle CORS pre-flight requests like:

```r
app$options("/route", function(req, res) {
    res$send("", headers = list(
                        `Access-Control-Allow-Origin` = "*",
                        `Access-Control-Allow-Methods` = "*",
                        `Access-Control-Allow-Headers` = "*"))
})
```

app$all is left alone to not break existing code. But this is up to the maintainers.